### PR TITLE
Fix ';' as alternative key to ':'

### DIFF
--- a/colemak-evil.el
+++ b/colemak-evil.el
@@ -409,7 +409,7 @@ Shortcuts:
 
 
 ;;allows you to use ; as :
-(define-key evil-motion-state-map ";" 'evil-ex-read-command)
+(define-key evil-motion-state-map ";" 'evil-ex)
 
 ;;hooks for hints
 (evil-ex-define-cmd "hints" 'colemak-evil-hints)


### PR DESCRIPTION
Trying to call evil-ex-read-command generates an error. ':' is already calling evil-ex instead, make ';' call that one too.
